### PR TITLE
Fixed variable lookup syntax in demo script

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -23,7 +23,7 @@ YELLOW='\033[1;33m'
 GRAY='\033[1;30m'
 RESET='\033[0m'
 
-if [[ -v "PYTHON" ]]
+if [ -v "PYTHON" ]
 then
     printf "${GRAY}Using Python: ${PYTHON}\n"
 else


### PR DESCRIPTION
```bash
demo.sh: line 26: conditional binary operator expected
demo.sh: line 26: syntax error near `"PYTHON"'
demo.sh: line 26: `if [[ -v "PYTHON" ]]'
```