### PR TITLE
pyce/__init__.py: bumping major version 2.0.0

### DIFF
--- a/pyce/__init__.py
+++ b/pyce/__init__.py
@@ -38,4 +38,4 @@ from pyce._imports import PYCEPathFinder, PYCEFileLoader
 
 
 __all__ = ['encrypt_path', 'HMACFailureException', 'PYCEPathFinder']
-__version__ = '1.0.0'
+__version__ = '2.0.0'


### PR DESCRIPTION
- We now only support Python 3.7, making this not backwards compatible