### PR TITLE
Fixed demo script not compatible with Bash < 4.2

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -23,7 +23,7 @@ YELLOW='\033[1;33m'
 GRAY='\033[1;30m'
 RESET='\033[0m'
 
-if [ -v "PYTHON" ]
+if [ -n "${PYTHON+x}" ]
 then
     printf "${GRAY}Using Python: ${PYTHON}\n"
 else


### PR DESCRIPTION
My previous fix to this was incorrect. The real problem is that `-v` only works with Bash >= 4.2 but macOS still uses 3.2. This should hopefully correct this simple check once and for all…