### PR TITLE
Look up encryption keys using file contents, not paths (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ similar to `python3 -mcompileall -b` where `-b` does an in place compilation.
 ```python
 from pyce import encrypt_path
 encrypt_path('pyce/hello.pyc')
-[('pyce/hello.pyce', '443df1d5f9914d13ed27950dd81aa2dd9d3b708be416c388f3226ad398d71a14')]
+[('da78a5bfe655d01334d7121dc0f021de870dc11515424f528045eb5f29098504', 'd11d969ab1d345df86f4180db549f5ffc400da10d03d43e1fa93eae373199dae')]
 ```
 
 Second, register your keys and try importing from the encrypted module or
@@ -33,7 +33,7 @@ package:
 
 ```python
 from pyce import PYCEPathFinder
-PYCEPathFinder.KEYS = {'pyce/hello.pyce' : '443df1d5f9914d13ed27950dd81aa2dd9d3b708be416c388f3226ad398d71a14'}
+PYCEPathFinder.KEYS = {'da78a5bfe655d01334d7121dc0f021de870dc11515424f528045eb5f29098504': 'd11d969ab1d345df86f4180db549f5ffc400da10d03d43e1fa93eae373199dae'}
 
 import sys
 sys.meta_path.insert(0, PYCEPathFinder)

--- a/pyce/_crypto.py
+++ b/pyce/_crypto.py
@@ -24,8 +24,8 @@ Python that can load encrypted files.
 Example use:
 
 >>> from pyce.crypto import encrypt_path, decryptf
->>> path, key = encrypt_path('pyce/hello.pyc')[0]
->>> print(decryptf(path, key))
+>>> hash, key = encrypt_path('pyce/hello.pyc')[0]
+>>> print(decryptf(hash, key))
 """
 
 
@@ -79,7 +79,7 @@ def encrypt_path(path: str, extensions: Set[str] = ENC_EXT, exclusions:
         exclusions: files that should not be encrypted
 
     Returns:
-        List of all paths and their encryption key
+        List of hashes of all encrypted files with their encryption key
     """
     if exclusions is None:
         exclusions = set()
@@ -118,8 +118,8 @@ def encrypt_path(path: str, extensions: Set[str] = ENC_EXT, exclusions:
                 data = openf.read()
 
                 # hash
-                hashv = srchash(data)
-                key = hashv.digest()
+                plaintext_hash = srchash(data)
+                key = plaintext_hash.digest()
 
                 # encrypt
                 cipher = Cipher(CIPHER(key), MODE(key[0:16]), backend=BACKEND)
@@ -131,12 +131,21 @@ def encrypt_path(path: str, extensions: Set[str] = ENC_EXT, exclusions:
                 openf.write(ciphertext)
 
                 # append HMAC
-                openf.write(hmac(key, ciphertext, HMAC_HS).digest())
+                ciphertext_hmac = hmac(key, ciphertext, HMAC_HS).digest()
+                openf.write(ciphertext_hmac)
 
             new_absolute_path, ext = splitext(absolute_path)
             new_absolute_path += ext + 'e'
             rename(absolute_path, new_absolute_path)
-            manifest.append((new_absolute_path, hashv.hexdigest()))
+
+            # add the decryption key for this file together with a hash of its
+            # encrypted contents. The import mechanism will then look up the
+            # required key by producing this same hash again at runtime.
+            encrypted_data = ciphertext + ciphertext_hmac
+            ciphertext_hash = srchash(encrypted_data)
+            manifest.append(
+                (ciphertext_hash.hexdigest(), plaintext_hash.hexdigest())
+            )
 
     return manifest
 


### PR DESCRIPTION
This is an attempt at solving issue #6 where the encryption key lookup
would only work when the code was executed from a specific path.

Instead of using relative file system paths, this change computes a
hash of the encrypted file's contents and stores the encryption key
with it. Upon import, the same hash is produced again to find the right
decryption key for the file in question.