### PR TITLE
Add a helper function to simplify adding the import hook

### DIFF
--- a/pyce/__init__.py
+++ b/pyce/__init__.py
@@ -23,19 +23,21 @@ files with a SHA-512 HMAC.
 
 You can enable the Python format for your interpreter by doing the following:
 
->>> import sys
->>> from pyce import PYCEPathFinder
->>> sys.meta_path.insert(0, PYCEPathFinder)
+>>> from pyce import add_import_hook
+>>> add_import_hook()
 
-If you had encrypted Python code, you'd want to then set the `KEYS` variable
-to an appropriate value (PYCEPathFinder.KEYS).
-
+If you had encrypted Python code, you would want to then pass the keys for
+encryption/decryption to the add_import_hook call, with the appropriate
+format.
 """
 
 
 from pyce._crypto import encrypt_path, HMACFailureException
-from pyce._imports import PYCEPathFinder, PYCEFileLoader
+from pyce._imports import PYCEPathFinder, PYCEFileLoader, add_import_hook
 
 
-__all__ = ['encrypt_path', 'HMACFailureException', 'PYCEPathFinder']
+__all__ = [
+    'add_import_hook', 'encrypt_path', 'HMACFailureException',
+    'PYCEPathFinder',
+]
 __version__ = '2.0.0'

--- a/pyce/_imports.py
+++ b/pyce/_imports.py
@@ -164,3 +164,19 @@ class PYCEPathFinder(PathFinder):
             if sorocospec is not None:
                 break
         return sorocospec
+
+
+def add_import_hook(keys=None):
+    """Adds the import mechanism support that enables importing pyce files.
+
+    Arguments:
+        keys: A mapping of normalized filenames to keys. (optional)
+
+    Returns:
+        None
+    """
+    if keys is None:
+        keys = {}
+
+    PYCEPathFinder.KEYS = keys
+    sys.meta_path.insert(0, PYCEPathFinder)


### PR DESCRIPTION
It is the most common use case and should be as simple as making a
function call, instead of having the user deal with a custom class and
sys.meta_path.