### PR TITLE
Allow decrypting of modules on different drive letter to the working …

### DIFF
--- a/pyce/_imports.py
+++ b/pyce/_imports.py
@@ -69,8 +69,14 @@ class PYCEFileLoader(SourcelessFileLoader):
         path = self.get_filename(fullname)
         data = self.get_data(path)
 
+        # Relative paths are impossible on Windows if the target file is on a different drive letter to the working directory
+        try:
+            r_path = relpath(path)
+        except:
+            # well, we tried
+            r_path = path
         # It is important to normalize path case for platforms like Windows
-        data = decrypt(data, PYCEPathFinder.KEYS[normcase(relpath(path))])
+        data = decrypt(data, PYCEPathFinder.KEYS[normcase(r_path)])
 
         # Call _classify_pyc to do basic validation of the pyc but ignore the
         # result. There's no source to check against.


### PR DESCRIPTION
…directory under Windows. (Full path is required in key).

This could be required if for example, the application is frozen with a tool such as pyInstaller, and that executable is run from a drive other than C: